### PR TITLE
Gpsversion fixed

### DIFF
--- a/ExifLibrary/ExifExtendedProperty.cs
+++ b/ExifLibrary/ExifExtendedProperty.cs
@@ -148,7 +148,7 @@ namespace ExifLibrary
 
     /// <summary>
     /// Represents the exif version as a 4 byte ASCII string. (EXIF Specification: UNDEFINED) 
-    /// Used for the ExifVersion, FlashpixVersion, InteroperabilityVersion and GPSVersionID fields.
+    /// Used for the ExifVersion, FlashpixVersion and InteroperabilityVersion fields.
     /// </summary>
     public class ExifVersion : ExifProperty
     {
@@ -186,6 +186,28 @@ namespace ExifLibrary
                     return new ExifInterOperability(ExifTagFactory.GetTagID(mTag), 7, 4, data);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Represents a version as a 4 byte byte array. (Specification: int8u[4]) 
+    /// Used for the GPSVersionID field.
+    /// </summary>
+    public class VersionID : ExifByteArray
+    {
+        public VersionID(ExifTag tag, byte [] value)
+            : base(tag, value)
+        {
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var b in Value)
+            {
+                sb.Append(b).Append('.');
+            }
+            return sb.ToString().TrimEnd('.');
         }
     }
 

--- a/ExifLibrary/ExifPropertyFactory.cs
+++ b/ExifLibrary/ExifPropertyFactory.cs
@@ -134,7 +134,7 @@ namespace ExifLibrary
             else if (ifd == IFD.GPS)
             {
                 if (tag == 0) // GPSVersionID
-                    return new ExifVersion(ExifTag.GPSVersionID, ExifBitConverter.ToString(value));
+                    return new VersionID(ExifTag.GPSVersionID, value);
                 else if (tag == 1) // GPSLatitudeRef
                     return new ExifEnumProperty<GPSLatitudeRef>(ExifTag.GPSLatitudeRef, (GPSLatitudeRef)value[0]);
                 else if (tag == 2) // GPSLatitude


### PR DESCRIPTION
Exif Property GPSVersionID fixed
- array of 4 characters replaced by array of 4 bytes
- exiftool and other references use this format
- tested with reference images of [exif-samples](https://github.com/ianare/exif-samples/tree/master/jpg/gps ) 