### PR TITLE
Remove MarkerSize from 64Kb header length calculation in JPEG Save File.

### DIFF
--- a/ExifLibrary/JPEGFile.cs
+++ b/ExifLibrary/JPEGFile.cs
@@ -197,9 +197,8 @@ namespace ExifLibrary
             // Write sections
             foreach (JPEGSection section in Sections)
             {
-                // Section header (including length bytes and section marker) 
-                // must not exceed 64 kB.
-                if (section.Header.Length + 2 + 2 > 64 * 1024)
+                // Section header (including length bytes) must not exceed 64 kB.
+                if (section.Header.Length + 2 > 64 * 1024)
                     throw new SectionExceeds64KBException();
 
                 // APP sections must have a header.


### PR DESCRIPTION
I have removed the marker from the calculation as per my understanding of the [specification](https://www.w3.org/Graphics/JPEG/itu-t81.pdf)  Page 37 - B.1.1.4 Marker segments.  It shouldn't be included and its presence is causing an exception to be thrown for valid images.

I can provide sample image(s) if required but these are generated on moto g(7) power phones.