### PR TITLE
Fix the safety checks for invalid IFD offsets

### DIFF
--- a/ExifLibrary/JPEGFile.cs
+++ b/ExifLibrary/JPEGFile.cs
@@ -586,12 +586,13 @@ namespace ExifLibrary
                 ifdqueue.RemoveAt(0);
 
                 // Field count
-                ushort fieldcount = conv.ToUInt16(header, ifdoffset);
-                if (ifdoffset > header.Length - 1 || ifdoffset + 2 > header.Length)
+                if (ifdoffset < 0 || ifdoffset > header.Length - 1 || ifdoffset + 2 > header.Length)
                 {
                     Errors.Add(new ImageError(Severity.Warning, $"IFD field count overflow for IFD {currentifd}."));
                     continue;
                 }
+
+                ushort fieldcount = conv.ToUInt16(header, ifdoffset);
                 for (short i = 0; i < fieldcount; i++)
                 {
                     // Read field info


### PR DESCRIPTION
This fixes issue #87, which occurs because the IFD field count was being retrieved _before_ the offset value was bounds-checked against the header length. 